### PR TITLE
Quickfix: fix 'getState' error after insomnia update

### DIFF
--- a/src/insomnia/state.ts
+++ b/src/insomnia/state.ts
@@ -1,37 +1,30 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { BaseDoc } from './insomnia.types'
 
-let store: any = null
+let router: any = null
 
-export const getStore = (): any => {
-  if (!store) {
-    const root = document.querySelector('#root') as Record<string, any>
-    const parameter = Object.getOwnPropertyNames(root).findLast(x => x.startsWith('__reactContainer')) as string
-    store = root[parameter].memoizedState.element.props.store
+var getRouter = (): any => {
+  if (!router) {
+    const root = document.querySelector("#root") as Record<string, any>;
+    if (!root) {
+      return;
+    }
+    const parameter = Object.getOwnPropertyNames(root).findLast((x) => x.startsWith("__reactContainer"));
+    router = root[parameter as string]?.memoizedState?.element?.props?.router;
   }
+  return router;
+};
 
-  return store
+export const getState = () => {
+  const router = getRouter();
+  return router?.state;
+};
+
+export const getActiveWorkspaceId = (): string => {
+  const state = getState();
+  return state?.loaderData[":workspaceId"].activeWorkspace._id
 }
-
-export const getState = (): any => {
-  const store = getStore()
-  return store.getState()
-}
-
-export const getActiveWorkspace = (): BaseDoc => {
-  const state = getState()
-  const workspaceId = state.global.activeWorkspaceId
-  const workspace = state.entities.workspaces[workspaceId]
-  return workspace
-}
-
-export const getActiveEnvironment = (): BaseDoc | null => {
-  const state = getState()
-  const activeWorkspaceId = getActiveWorkspace()._id
-  const activeWorkspaceMeta = (Object.values(state.entities.workspaceMetas) as any[]).find(x => x.parentId === activeWorkspaceId) as BaseDoc
-  const activeEnvironmentId = activeWorkspaceMeta.activeEnvironmentId
-  const activeEnvironment = state.entities.environments[activeEnvironmentId] ?? null as (BaseDoc | null)
-
-  return activeEnvironment
+export const getActiveEnvironmentId = (): string => {
+  const state = getState();
+  return state?.loaderData[":workspaceId"].activeEnvironment._id
 }

--- a/src/insomnia/state.ts
+++ b/src/insomnia/state.ts
@@ -3,28 +3,28 @@
 
 let router: any = null
 
-var getRouter = (): any => {
+const getRouter = (): any => {
   if (!router) {
-    const root = document.querySelector("#root") as Record<string, any>;
+    const root = document.querySelector('#root') as Record<string, any>
     if (!root) {
-      return;
+      return
     }
-    const parameter = Object.getOwnPropertyNames(root).findLast((x) => x.startsWith("__reactContainer"));
-    router = root[parameter as string]?.memoizedState?.element?.props?.router;
+    const parameter = Object.getOwnPropertyNames(root).findLast((x) => x.startsWith('__reactContainer'))
+    router = root[parameter as string]?.memoizedState?.element?.props?.router
   }
-  return router;
-};
+  return router
+}
 
 export const getState = () => {
-  const router = getRouter();
-  return router?.state;
-};
+  const router = getRouter()
+  return router?.state
+}
 
 export const getActiveWorkspaceId = (): string => {
-  const state = getState();
-  return state?.loaderData[":workspaceId"].activeWorkspace._id
+  const state = getState()
+  return state?.loaderData[':workspaceId'].activeWorkspace._id
 }
 export const getActiveEnvironmentId = (): string => {
-  const state = getState();
-  return state?.loaderData[":workspaceId"].activeEnvironment._id
+  const state = getState()
+  return state?.loaderData[':workspaceId'].activeEnvironment._id
 }

--- a/src/services/main.ts
+++ b/src/services/main.ts
@@ -61,13 +61,13 @@ export const init = async () => {
 }
 
 export const getCurrentTokenAsync = async (): Promise<StoredToken | null> => {
-  const activeWorkspaceId = getActiveWorkspaceId();
+  const activeWorkspaceId = getActiveWorkspaceId()
   const activeEnvironmentId = getActiveEnvironmentId()
   return await getTokenAsync(activeWorkspaceId, activeEnvironmentId ?? null)
 }
 
 export const getLatestTokenAsync = async (): Promise<StoredToken | null> => {
-  const activeWorkspaceId = getActiveWorkspaceId();
+  const activeWorkspaceId = getActiveWorkspaceId()
   const tokens = await getTokensAsync(activeWorkspaceId)
   if (tokens.length === 0) return null
   return tokens.reduce((prev, curr) => prev.createdAt > curr.createdAt ? prev : curr, tokens[0] ?? null)

--- a/src/services/main.ts
+++ b/src/services/main.ts
@@ -1,18 +1,18 @@
-import { BaseDoc, subscribe, getActiveEnvironment, getActiveWorkspace } from '../insomnia'
+import { BaseDoc, subscribe, getActiveEnvironmentId, getActiveWorkspaceId } from '../insomnia'
 import { database } from '../services/db'
 import { StoredToken } from './main.types'
 
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 const onTokenUpdate = (token: BaseDoc) => {
-  const activeWorkspace = getActiveWorkspace()
-  const activeEnvironment = getActiveEnvironment()
+  const activeWorkspaceId = getActiveWorkspaceId()
+  const activeEnvironmentId = getActiveEnvironmentId()
   // console.log('[oa2-mate] Token updated', { requestId: token.parentId, accessToken: token.accessToken })
 
   const tokenToStore: StoredToken = {
     accessToken: token.accessToken,
-    environmentId: activeEnvironment?._id ?? null,
-    workspaceId: activeWorkspace._id,
+    environmentId: activeEnvironmentId ?? null,
+    workspaceId: activeWorkspaceId,
     createdAt: Date.now(),
   }
 
@@ -61,14 +61,14 @@ export const init = async () => {
 }
 
 export const getCurrentTokenAsync = async (): Promise<StoredToken | null> => {
-  const activeWorkspace = getActiveWorkspace()
-  const activeEnvironment = getActiveEnvironment()
-  return await getTokenAsync(activeWorkspace._id, activeEnvironment?._id ?? null)
+  const activeWorkspaceId = getActiveWorkspaceId();
+  const activeEnvironmentId = getActiveEnvironmentId()
+  return await getTokenAsync(activeWorkspaceId, activeEnvironmentId ?? null)
 }
 
 export const getLatestTokenAsync = async (): Promise<StoredToken | null> => {
-  const activeWorkspace = getActiveWorkspace()
-  const tokens = await getTokensAsync(activeWorkspace._id)
+  const activeWorkspaceId = getActiveWorkspaceId();
+  const tokens = await getTokensAsync(activeWorkspaceId)
   if (tokens.length === 0) return null
   return tokens.reduce((prev, curr) => prev.createdAt > curr.createdAt ? prev : curr, tokens[0] ?? null)
 }


### PR DESCRIPTION
closes #7 

Quickfix to retrieve the workspaceId/environmentId from the (apparently) new location. I don't know if this is the best way to address the root issue.

Tested locally by runnin:

npm install
npm run build

Copying the generated dist/index.js to %APPDATA%/insomnia/plugins/insomnia-plugin-oa2-mate and restarting insomnia

